### PR TITLE
Give Page Redesign

### DIFF
--- a/_data/give_reasons.yml
+++ b/_data/give_reasons.yml
@@ -1,0 +1,9 @@
+- icon: users
+  title: Community-Led Projects
+  content: Every initiative is designed and driven by local community members, not outsiders.
+- icon: hand-holding-heart
+  title: 100% Goes to the Field
+  content: All administrative costs are covered by our Board, so every dollar you give reaches the community.
+- icon: seedling
+  title: Lasting Impact
+  content: Supporting education, health, and quality of life for children and adults in Kenya.

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
-<div class='sticky-top navbar navbar-expand-md bg-light'>
+<div class='sticky-top navbar navbar-expand-md bg-light border-bottom border-primary border-3'>
   <div class='container-xxl gx-5'>
     <a class='navbar-brand' href='/'>
       <img class='d-none d-sm-inline' height='50' src='/assets/images/full_logo.png' alt='Komolion Fund Logo'>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
     <script src="{{'/assets/js/jquery.min.js' | prepend: site.baseurl}}"></script>
     <script src="{{'/assets/js/popper.min.js' | prepend: site.baseurl}}"></script>
     <script src="{{'/assets/js/bootstrap.min.js' | prepend: site.baseurl}}"></script>
-    <script src="https://donorbox.org/widget.js" paypalExpress="false"></script>
+    <script type="module" src="https://donorbox.org/widgets.js" async></script>
     {% seo %}
   </head>
   <body>

--- a/_sass/give.scss
+++ b/_sass/give.scss
@@ -1,5 +1,5 @@
 @use 'variables' as *;
 
 dbox-widget {
-  min-height: 585px;
+  min-height: 650px;
 }

--- a/_sass/give.scss
+++ b/_sass/give.scss
@@ -1,5 +1,5 @@
 @use 'variables' as *;
 
-iframe.give-frame {
-  max-width: 425px;
+dbox-widget {
+  min-height: 585px;
 }

--- a/give.html
+++ b/give.html
@@ -6,7 +6,7 @@ disclaimer: Komolion Human Development Fund, Inc. will not provide any goods or 
 <div class='bg-light'>
   <div class='container-xxl gx-5'>
     <div class='row'>
-      <h1 class='col text-center mt-4'>{{ page.title }}</h1>
+      <h1 class='col text-center mt-5 mb-4'>{{ page.title }}</h1>
     </div>
     <hr>
     <div class='row justify-content-center align-items-start'>
@@ -33,8 +33,10 @@ disclaimer: Komolion Human Development Fund, Inc. will not provide any goods or 
           </div>
         </div>
       </div>
-      <dbox-widget campaign="komolion-fund-donations" type="donation_form" enable-auto-scroll="true" class="col-12 col-lg-5 col-xl-4 mb-5"></dbox-widget>
+      <dbox-widget campaign="komolion-fund-donations" type="donation_form" enable-auto-scroll="true"
+        class="col-12 col-lg-5 col-xl-4 mb-5"></dbox-widget>
       <div class='d-lg-none col-12 d-flex flex-column gap-4 mb-4'>
+        <p class='small text-uppercase fw-semibold text-muted mb-0'>YOUR DONATION AT WORK</p>
         {% for reason in site.data.give_reasons %}
         <div class='d-flex gap-3 align-items-start'>
           <i class='fa fa-{{ reason.icon }} fa-2x text-primary mt-1 col-auto'></i>

--- a/give.html
+++ b/give.html
@@ -1,6 +1,5 @@
 ---
 title: Empower Locals to Change Lives
-body: Komolion Human Development Fund encourages and provides funding for projects in local communities that are designed by community members to enable increased education, health, cooperation, poverty reduction and quality of life for the entire community. We envision a world in which children and adults have opportunities to thrive personally and to make positive contributions to their communities.
 disclaimer: Komolion Human Development Fund, Inc. will not provide any goods or services in consideration of the gift received. This contribution is made with the understanding that Komolion Human Development Fund, Inc. has complete control and administration over the use of the donated funds. Komolion Human Development Fund, Inc. is a non-profit organization pursuant to Section 501(c)(3) of the United States Internal Revenue Code. Your donation may qualify for an income tax deduction in accordance with Federal and/or State income tax laws. Please consult with your tax advisor to determine whether your donation is tax deductible in whole or in part. Nothing in this communication is intended to constitute legal or tax advice.
 ---
 
@@ -10,13 +9,45 @@ disclaimer: Komolion Human Development Fund, Inc. will not provide any goods or 
       <h1 class='col text-center mt-4'>{{ page.title }}</h1>
     </div>
     <hr>
-    <div class='row justify-content-center'>
-      <iframe src='https://donorbox.org/embed/komolion-fund-donations?default_interval=o' allow='payment' scrolling='no'
-        class='give-frame col-12 col-md-6 col-lg-5 col-xl-4 mb-5' name='donorbox'></iframe>
-      <div class='col-12 col-md-6 col-lg-7 col-xl-8'>
-        <p class='fs-5 fw-bold'>{{ page.body }}</p>
-        <p class='text-black-50 mb-5'>{{ page.disclaimer }}</p>
+    <div class='row justify-content-center align-items-start'>
+      <div class='d-none d-lg-flex col-lg-7 col-xl-8 flex-column gap-4 pe-5 mb-5'>
+        <p class='small text-uppercase fw-semibold text-muted mb-0'>YOUR DONATION AT WORK</p>
+        {% for reason in site.data.give_reasons %}
+        <div class='d-flex gap-3 align-items-start'>
+          <i class='fa fa-{{ reason.icon }} fa-2x text-primary mt-1 col-auto'></i>
+          <div>
+            <p class='fw-bold mb-1'>{{ reason.title }}</p>
+            <p class='text-muted mb-0'>{{ reason.content }}</p>
+          </div>
+        </div>
+        {% endfor %}
+        <div class='border-top border-primary border-2 pt-4'>
+          <p class='small text-uppercase fw-semibold text-muted mb-3'>By the numbers</p>
+          <div class='row g-3'>
+            {% for number in site.data.numbers %}
+            <div class='col-3'>
+              <p class='fw-bold fs-4 text-primary mb-0'>{{ number.content }}</p>
+              <p class='small text-muted mb-0'>{{ number.title }}</p>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
+      <dbox-widget campaign="komolion-fund-donations" type="donation_form" enable-auto-scroll="true" class="col-12 col-lg-5 col-xl-4 mb-5"></dbox-widget>
+      <div class='d-lg-none col-12 d-flex flex-column gap-4 mb-4'>
+        {% for reason in site.data.give_reasons %}
+        <div class='d-flex gap-3 align-items-start'>
+          <i class='fa fa-{{ reason.icon }} fa-2x text-primary mt-1 col-auto'></i>
+          <div>
+            <p class='fw-bold mb-1'>{{ reason.title }}</p>
+            <p class='text-muted mb-0'>{{ reason.content }}</p>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    <div class='row'>
+      <p class='col-12 small text-muted mb-4'>{{ page.disclaimer }}</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Redesigning the Give page

- Update from Classic to OmniGive Donorbox embedded form
- Replace text with "Your donation at work" and "By the numbers" sections, with "By the numbers" disappearing on medium and smaller screens
- Move disclaimer text below form regardless of view size
- Update spacing around Give page title to match new spacing on Team page
- Add green bottom border on nav bar